### PR TITLE
tidy up about text

### DIFF
--- a/data/pages.collection.json
+++ b/data/pages.collection.json
@@ -1,7 +1,7 @@
 [
   {
       "title": "Home",
-      "subtitle": "An event that is run by London's biggest JavaScript meetups",
+      "subtitle": "An event run by London's biggest JavaScript meetups",
       "url": "home",
       "type": "Home",
       "description": "<p>CityJS Conference&nbsp;is a JavaScript festival across London, a joint event comprised of London's JavaScript meetups, including&nbsp;<a href=\"https:\/\/www.meetup.com\/js-monthly\/\">JS Monthly<\/a>,&nbsp;<a href=\"https:\/\/www.meetup.com\/halfstack\/\">Halfstack<\/a> and <a href=\"https:\/\/www.meetup.com\/london-nodejs\/\">Node User Group.<\/a><\/p>\n<p>This is a fantastic opportunity<span style=\"font-weight: 400;\">&nbsp;for the&nbsp;JavaScript community, and for those aiming to stay in touch with the industry, to be updated on innovative changes around the industry and JS as an entity. You can absorb knowledge while hopping on and off thought-provoking workshops and talks - this is possibly the most central and reasonably priced event to attend in London.&nbsp;<\/span><\/p>",


### PR DESCRIPTION
an extra change to go with what was changed in the first push I did straight to the microsite branch - change year to 2021 to clear the old sponsors out, change some text for the about, take out the old meetup group which has closed down. take out reference to the forthcoming 2020 conference (has been and gone)